### PR TITLE
Adapt argument type of `GetColor`

### DIFF
--- a/src/raylib.lisp
+++ b/src/raylib.lisp
@@ -2095,7 +2095,7 @@
 ;;RLAPI Color GetColor(int hexValue);                               // Returns a Color struct from hexadecimal value
 (defcfun "GetColor" (:struct %color)
  "Returns a Color struct from hexadecimal value"
- (hex-value :int))
+ (hex-value :unsigned-int))
 
 ;;RLAPI Color Fade(Color color, float alpha);                       // Color fade-in or fade-out, alpha goes from 0.0f to 1.0f
 (defcfun "Fade" (:struct %color)


### PR DESCRIPTION
With a recent change in raylib, `GetColor` now takes an unsigned int.

https://github.com/raysan5/raylib/commit/cac856119c23898579fc237703a8ff3bda207dc6

This change is available in raylib 4.0

https://github.com/raysan5/raylib/blob/4.0.0/src/raylib.h#L1307