### PR TITLE
On Windows and MSYS2/mingw the raylib dll can also be named libraylib.dll

### DIFF
--- a/src/library.lisp
+++ b/src/library.lisp
@@ -2,7 +2,7 @@
 (define-foreign-library libraylib
   (:darwin "libraylib.dylib")
   (:unix "libraylib.so")
-  (:windows "raylib.dll")
+  (:windows (:or "raylib.dll" "libraylib.dll"))
   (t (:default "libraylib")))
 
 (unless (foreign-library-loaded-p 'libraylib)


### PR DESCRIPTION
On Windows and MSYS2/mingw the raylib dll can also be named libraylib.dll