### PR TITLE
Add draw-line-bezier-(quad,cubic) bindings

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -354,6 +354,8 @@
     #:draw-line-v
     #:draw-line-ex
     #:draw-line-bezier
+    #:draw-line-bezier-quad
+    #:draw-line-bezier-cubic
     #:draw-line-strip
     #:draw-circle
     #:draw-circle-sector

--- a/src/raylib.lisp
+++ b/src/raylib.lisp
@@ -2768,6 +2768,23 @@
  (thick :float)
  (color (:struct %color)))
 
+;;RLAPI void DrawLineBezierQuad(Vector2 startPos, Vector2 endPos, Vector2 controlPos, float thick, Color color); // Draw line using quadratic bezier curves with a control point
+(defcfun "DrawLineBezierQuad" :void
+  (start-pos (:struct %vector2))
+  (end-pos (:struct %vector2))
+  (control-pos (:struct %vector2))
+  (thick :float)
+  (color (:struct %color)))
+
+;;RLAPI void DrawLineBezierCubic(Vector2 startPos, Vector2 endPos, Vector2 startControlPos, Vector2 endControlPos, float thick, Color color); // Draw line using cubic bezier curves with 2 control points
+(defcfun "DrawLineBezierCubic" :void
+  (start-pos (:struct %vector2))
+  (end-pos (:struct %vector2))
+  (start-control-pos (:struct %vector2))
+  (end-control-pos (:struct %vector2))
+  (thick :float)
+  (color (:struct %color)))
+
 ;;RLAPI void DrawLineStrip(Vector2 *points, int numPoints, Color color);                                   // Draw lines sequence
 (defcfun "DrawLineStrip" :void
   "Draw lines sequence"


### PR DESCRIPTION
Hi @longlene!  Thank you for creating this repo!  I was having a lot of fun testing it out to make games.  There are some functions that I want to use for my games that don't have bindings yet so I committed those to my fork.  Please let me know if you'd want this kind of small PRs in the future.

This PR adds the binding functions to raylib 4.0.0's `DrawLineBezierQuad` and `DrawLineBezierCubic`.  See original source [here](https://github.com/raysan5/raylib/blob/4.0.0/src/raylib.h#L1152-L1153).