### PR TITLE
Use keywords instead of constants for C enums

### DIFF
--- a/src/raylib.lisp
+++ b/src/raylib.lisp
@@ -1269,7 +1269,26 @@
 ;;    LOG_FATAL,          // Fatal logging, used to abort program: exit(EXIT_FAILURE)
 ;;    LOG_NONE            // Disable logging
 ;;} TraceLogLevel;
-;;
+
+(cffi:defcenum TraceLogLevel
+  "Trace log level"
+  ;; Display all logs
+  (:log-all 0)
+  ;; Trace logging, intended for internal use only
+  (:log-trace 1)
+  ;; Debug logging, used for internal debugging, it should be disabled on release builds
+  (:log-debug 2)
+  ;; Info logging, used for program execution info
+  (:log-info 3)
+  ;; Warning logging, used on recoverable failures
+  (:log-warning 4)
+  ;; Error logging, used on unrecoverable failures
+  (:log-error 5)
+  ;; Fatal logging, used to abort program: exit(EXIT_FAILURE)
+  (:log-fatal 6)
+  ;; Disable logging
+  (:log-none 7))
+
 ;;// Keyboard keys (US keyboard layout)
 ;;// NOTE: Use GetKeyPressed() to allow redefining
 ;;// required keys for alternative layouts
@@ -2346,7 +2365,7 @@
 ;;RLAPI void SetTraceLogLevel(int logType);                         // Set the current threshold (minimum) log level
 (defcfun "SetTraceLogLevel" :void
  "Set the current threshold (minimum) log level"
- (log-type :int))
+ (log-type TraceLogLevel))
 
 ;;RLAPI void SetTraceLogExit(int logType);                          // Set the exit threshold (minimum) log level
 (defcfun "SetTraceLogExit" :void

--- a/src/raylib.lisp
+++ b/src/raylib.lisp
@@ -1226,20 +1226,36 @@
 ;;    FLAG_INTERLACED_HINT    = 0x00010000    // Set to try enabling interlaced video format (for V3D)
 ;;} ConfigFlags;
 
-(define-constant   +flag-vsync-hint+         #x00000040)
-(define-constant   +flag-fullscreen-mode+    #x00000002)
-(define-constant   +flag-window-resizable+   #x00000004)
-(define-constant   +flag-window-undecorated+ #x00000008)
-(define-constant   +flag-window-hidden+      #x00000080)
-(define-constant   +flag-window-minimized+   #x00000200)
-(define-constant   +flag-window-maximized+   #x00000400)
-(define-constant   +flag-window-unfocused+   #x00000800)
-(define-constant   +flag-window-topmost+     #x00001000)
-(define-constant   +flag-window-always-run+  #x00000100)
-(define-constant   +flag-window-transparent+ #x00000010)
-(define-constant   +flag-window-highdpi+     #x00002000)
-(define-constant   +flag-msaa-4x-hint+       #x00000020)
-(define-constant   +flag-interlaced-hint+    #x00010000)
+(defbitfield ConfigFlags
+  "System/Window config flags"
+  ;; Set to try enabling V-Sync on GPU
+  (:flag-vsync-hint #x00000040)
+  ;; Set to run program in fullscreen
+  (:flag-fullscreen-mode #x00000002)
+  ;; Set to allow resizable window
+  (:flag-window-resizable #x00000004)
+  ;; Set to disable window decoration (frame and buttons)
+  (:flag-window-undecorated #x00000008)
+  ;; Set to hide window
+  (:flag-window-hidden #x00000080)
+  ;; Set to minimize window (iconify)
+  (:flag-window-minimized #x00000200)
+  ;; Set to maximize window (expanded to monitor)
+  (:flag-window-maximized #x00000400)
+  ;; Set to window non focused
+  (:flag-window-unfocused #x00000800)
+  ;; Set to window always on top
+  (:flag-window-topmost #x00001000)
+  ;; Set to allow windows running while minimized
+  (:flag-window-always-run #x00000100)
+  ;; Set to allow transparent framebuffer
+  (:flag-window-transparent #x00000010)
+  ;; Set to support HighDPI
+  (:flag-window-highdpi #x00002000)
+  ;; Set to try enabling MSAA 4X
+  (:flag-msaa-4x-hint #x00000020)
+  ;; Set to try enabling interlaced video format (for V3D)
+  (:flag-interlaced-hint #x00010000))
 
 ;;// Trace log level
 ;;// NOTE: Organized by priority level
@@ -2325,7 +2341,7 @@
 ;;RLAPI void SetConfigFlags(unsigned int flags);                    // Setup window configuration flags (view FLAGS)
 (defcfun "SetConfigFlags" :void
  "Setup window configuration flags (view FLAGS)"
- (flags :unsigned-int))
+ (flags ConfigFlags))
 
 ;;RLAPI void SetTraceLogLevel(int logType);                         // Set the current threshold (minimum) log level
 (defcfun "SetTraceLogLevel" :void


### PR DESCRIPTION
Using `cffi:defbitfield` makes writing flag combinations simpler. With this change you can just write

```
  (raylib:set-config-flags '(:flag-window-highdpi :flag-window-undecorated))
```

I think all enums should be converted to keywords since it is the lisp convention. If you're good with this change, I'll open up a few more PRs to convert the other enums.