### PR TITLE
Rename image format access to avoid name collision

### DIFF
--- a/src/raylib.lisp
+++ b/src/raylib.lisp
@@ -423,7 +423,7 @@
                       (setf width (image-width object))
                       (setf height (image-height object))
                       (setf maps (image-maps object))
-                      (setf ft (image-format object))))
+                      (setf ft (image-ft object))))
 
 (defmethod translate-from-foreign (pointer (type image-type))
   (with-foreign-slots ((data width height maps ft) pointer (:struct %image))


### PR DESCRIPTION
The `image-format` symbol is already used for the `ImageFormat` function, so working with Images now causes errors as `image-format` calls the wrong function. Reverting to `image-ft` appears to fix this issue.