### PR TITLE
export #'make-rgba, so that downstream can easily use custom colors

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -3,6 +3,7 @@
   (:use #:cl #:cffi #:alexandria)
   (:export
     ;; Basic Colors
+    #:make-rgba
     #:+lightgray+
     #:+gray+
     #:+darkgray+


### PR DESCRIPTION
I have exposed `#'make-rgba`, so that I can use arbitrary colors directly